### PR TITLE
Drop Julia 0.5; use Memento 0.6.0

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.5
+julia 0.6
 Memento 0.6.0
 Humanize 0.4.1

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
 julia 0.5
-Memento 0.0.1
+Memento 0.6.0
 Humanize 0.4.1

--- a/src/Trace.jl
+++ b/src/Trace.jl
@@ -3,7 +3,7 @@ module Trace
 using Memento
 using Humanize
 
-import Memento: Attribute
+import Memento: Attribute, addlevel!, getlogger
 
 global ENABLED = false
 
@@ -28,7 +28,7 @@ Enables logging for all subsequent tracing macros and adds a "trace" (5) logging
 function enable()
     ENABLED::Bool &&  return  # exit early if enabled has already been set
     global ENABLED = true
-    add_level(get_logger(), "trace", 5)
+    addlevel!(getlogger(), "trace", 5)
 end
 
 include(joinpath(Pkg.dir("Trace"), "src", "record.jl"))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,7 +31,7 @@ skip_trace = median(map(1:1000) do i
     tic()
     @info(logger, "My skipped message")
     res = toq()
-    @test isempty(takebuf_string(io))
+    @test isempty(String(take!(io)))
     return res
 end)
 
@@ -42,7 +42,7 @@ log_trace = median(map(1:1000) do i
     tic()
     @info(logger, "My logged message")
     res = toq()
-    @test contains(takebuf_string(io), "My logged message")
+    @test contains(String(take!(io)), "My logged message")
     return res
 end)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -67,5 +67,5 @@ println("Logged log time: $log_log")
 @test skip_trace < skip_log
 @test skip_trace < log_trace
 
-set_level(logger, "trace")
+Memento.setlevel!(logger, "trace")
 @trace(logger, median(rand(1000)))


### PR DESCRIPTION
Some changes are needed to match the latest release of Memento (in particular: `addlevel!` and `getlogger` replacing `add_level` and `get_logger`).
Since Memento 0.6.0 requires Julia 0.6, the REQUIRE file is updated accordingly.
